### PR TITLE
Use Rack helpers to detect the scheme

### DIFF
--- a/lib/breezy_pdf/intercept/base.rb
+++ b/lib/breezy_pdf/intercept/base.rb
@@ -3,6 +3,9 @@
 module BreezyPDF::Intercept
   # :nodoc
   class Base
+    include Rack::Request::Env
+    include Rack::Request::Helpers
+
     attr_reader :app, :env
 
     def initialize(app, env)
@@ -24,17 +27,15 @@ module BreezyPDF::Intercept
     end
 
     def rendered_url
-      "#{env['rack.url_scheme']}://#{env['SERVER_NAME']}#{port}" \
-      "#{path}#{query_string}"
+      "#{base_url}#{path}#{query_string}"
     end
 
     def requested_url
-      "#{env['rack.url_scheme']}://#{env['SERVER_NAME']}#{port}" \
-      "#{env['PATH_INFO']}#{query_string}"
+      "#{base_url}#{env['PATH_INFO']}#{query_string}"
     end
 
     def base_url
-      "#{env['rack.url_scheme']}://#{env['SERVER_NAME']}#{port}"
+      "#{scheme}://#{env['SERVER_NAME']}#{port}"
     end
 
     def port

--- a/lib/breezy_pdf/response.rb
+++ b/lib/breezy_pdf/response.rb
@@ -17,7 +17,7 @@ module BreezyPDF
     end
 
     def method_missing(method, *_args, &_blk)
-      if body.keys.include?(method.to_s)
+      if body.key?(method.to_s)
         body[method.to_s]
       else
         super
@@ -25,7 +25,7 @@ module BreezyPDF
     end
 
     def respond_to_missing?(method, *)
-      body.keys.include?(method.to_s)
+      body.key?(method.to_s)
     end
 
     private

--- a/test/breezy_pdf/intercept/base_test.rb
+++ b/test/breezy_pdf/intercept/base_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BreezyPDF::Intercept::BaseTest < BreezyTest
+  def test_forwared_scheme
+    app = proc {}
+    env = { "HTTP_X_FORWARDED_SCHEME" => "https", "SERVER_NAME" => "example.com", "SERVER_PORT" => 443 }
+    base_url = BreezyPDF::Intercept::Base.new(app, env).send(:base_url)
+
+    assert_equal("https://example.com", base_url)
+  end
+
+  def test_rack_url_scheme
+    app = proc {}
+    env = { "rack.url_scheme" => "https", "SERVER_NAME" => "example.com", "SERVER_PORT" => 443 }
+    base_url = BreezyPDF::Intercept::Base.new(app, env).send(:base_url)
+
+    assert_equal("https://example.com", base_url)
+  end
+end


### PR DESCRIPTION
Take advantage of Rack's helpers to determine if the request scheme is `https` or not.

+ Fixes #18
+ DRY up code